### PR TITLE
Added go-contribution-guidelines.md

### DIFF
--- a/contribution-guidelines.md
+++ b/contribution-guidelines.md
@@ -18,6 +18,8 @@ If your pull request is not accepted on the first try, don't be discouraged! If 
 
 Each repository will have its own code and test conventions. Please make sure to review those before jumping in. Some general conventions are listed below.
 
+If you are contributing to a repository written in Go, please look at the [Go Contribution Guidelines](go-contribution-guidelines.md).
+
 ### Git
 
 We use a simple git branching model:

--- a/go-contribution-guidelines.md
+++ b/go-contribution-guidelines.md
@@ -1,0 +1,20 @@
+# Go Contribution Guidelines
+
+Many IPFS projects use Go. Please check these guidelines before contributing go code to an IPFS repository.
+
+## Requirements
+
+- Run `go fmt` before pushing any code.
+- Run `golint` and `go vet` too -- some things (like protobuf files) are expected to fail.
+
+## A Short Introduction
+
+If you are new to our Go development workflow:
+
+- Ensure you have [Go installed on your system](https://golang.org/doc/install).
+- Make sure that you have the environment variable `GOPATH` set somewhere, e.g. `$HOME/gopkg`
+- Clone ipfs into the path `$GOPATH/src/github.com/ipfs/go-ipfs`
+  - NOTE: This is true even if you have forked go-ipfs, dependencies in go are path based and must be in the right locations.
+- You are now free to make changes to the codebase as you please.
+- You can build the binary by running `go build ./cmd/ipfs` from the go-ipfs directory.
+  - NOTE: when making changes remember to restart your daemon to ensure its running your new code.


### PR DESCRIPTION
This solves an issue brought up in https://github.com/ipfs/go-ipfs/pull/1734; how do we maintain similar standards over many repositories using the same language without duplicating language guidelines? All go repositories should now point to this file, and we can update it accordingly. 

Most of this was pulled from https://github.com/ipfs/go-ipfs/blob/master/contribute.md. I have a branch ready to strip that file and point here if this is merged. 