### PR TITLE
Editing contributing

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -22,6 +22,7 @@ helping us improve our community.
 * [Contribution Guidelines](#contribution-guidelines)
 * [Community Guidelines](#community-guidelines)
 * [Community Improvement](#community-improvement)
+* [Helping in other ways](#helping-in-other-ways)
 
 ### Security Issues
 
@@ -48,7 +49,6 @@ uname -a >>/tmp/ipfs-bug-report
 
 It may also be relevant to look at the eventlog of your ipfs node, but we will request it if so.
 
-
 ### Protocol Design
 
 When considering protocol design proposals, we are looking for:
@@ -68,7 +68,6 @@ When considering design proposals for implementations, we are looking for:
 - A description of the problem this design proposal solves
 - Discussion of the tradeoffs involved
 - Discussion of the proposed solution
-
 
 ### Contribution Guidelines
 
@@ -91,3 +90,7 @@ There is also a more extensive [code-of-conduct](code-of-conduct.md).
 ### Community Improvement
 
 The IPFS community requires maintenance of various "public infrastructure" resources. These include documentation, github repositories, CI build bots, and more. There is also helping new users with questions, spreading theword about IPFS, and so on. Soon, we will be planning and running conferences. Please get in touch if you would like to help out.
+
+### Helping in other ways
+
+Protocol Labs occasionally is able to hire developers for part time or full time positions, to work on IPFS. If you are interested, check out [the job listings](http://ipn.io/join/#pm). If you'd like to help in other ways, [email @jbenet directly](mailto:juan@ipfs.io?subject=Contributing to IPFS).

--- a/contribution-guidelines.md
+++ b/contribution-guidelines.md
@@ -124,9 +124,9 @@ Write clean code. Universally formatted code promotes ease of writing, reading, 
 
 ### Tests
 
-Submit tests with your changes. Take a look at existing tests for inspiration. Run the full test suite on your branch before submitting a pull request.
+If the repository you are working on has a testing suite, submit tests with your changes. Take a look at existing tests for inspiration. Run the full test suite on your branch before submitting a pull request.
 
-For commandline tool changes, please write appropriate sharness tests.
+For command line tool changes, please write appropriate sharness tests.
 
 ### Documentation
 


### PR DESCRIPTION
I added a "Helping in other ways" section, and moved the commit sign off message to go-ipfs. This is only used in go-ipfs. I have moved it to the contribution guidelines for that repository, and have opened PR. I ran into at least one contributor who was intimidated by this section, and it is not currently mandatory for all repositories (although it potentially should be).