### PR TITLE
fix link to JS contrib guidelines

### DIFF
--- a/contribution-guidelines.md
+++ b/contribution-guidelines.md
@@ -46,7 +46,7 @@ Please look at the [Go Contribution Guidelines](go-contribution-guidelines.md).
 
 ### JavaScript
 
-Please look at the [JS Contribution Guidelines](js-contribution-guidelines.md).
+Please look at the [JS Contribution Guidelines](js-project-guidelines.md).
 
 ### Git
 


### PR DESCRIPTION
Link to JS contribution guidelines was pointing to a file that doesn't exist