### PR TITLE
Draft of js git commit convention

### DIFF
--- a/js-commit-guidelines.md
+++ b/js-commit-guidelines.md
@@ -1,16 +1,16 @@
 # Git Commit Guidelines
 
 We have very precise rules over how our git commit messages can be formatted.
-This leads to *more readable messages* that are easy to follow when
-looking through the *project history*.  But also,
-we use the git commit messages to *generate the change log*.
+This leads to more readable messages that are easy to follow when
+looking through the project history.  But also,
+we use the git commit messages to generate the change log.
 
 The commit message formatting can be added using a typical git workflow or
 through the use of a CLI wizard ([Commitizen](https://github.com/commitizen/cz-cli)).
 
 ### Commit Message Format
-Each commit message consists of a *header*, a *body* and a *footer*.
-The header has a special format that includes a *type*, a *scope* and a *subject*:
+Each commit message consists of a header, a body and a footer.
+The header has a special format that includes a type, a scope and a subject:
 
 ```
 <type>(<scope>): <subject>
@@ -20,7 +20,7 @@ The header has a special format that includes a *type*, a *scope* and a *subject
 <footer>
 ```
 
-The *header* is mandatory and the *scope* of the header is optional.
+The header is mandatory and the scope of the header is optional.
 
 Any line of the commit message cannot be longer 100 characters! This allows the message to be easier
 to read on GitHub as well as in various git tools.
@@ -56,12 +56,12 @@ The subject contains a succinct description of the change:
 * no dot (.) at the end
 
 ### Body
-Just as in the *subject*, use the imperative, present tense: "change" not "changed" nor "changes".
+Just as in the subject, use the imperative, present tense: "change" not "changed" nor "changes".
 The body should include the motivation for the change and contrast this with previous behavior.
 
 ### Footer
-The footer should contain any information about *breaking changes* and is also the place to
-reference GitHub issues that this commit *closes*.
+The footer should contain any information about breaking changes and is also the place to
+reference GitHub issues that this commit closes.
 
 **Breaking Changes** should start with the word `BREAKING CHANGE:` with a space or two newlines. The rest of the commit message is then used for this.
 

--- a/js-commit-guidelines.md
+++ b/js-commit-guidelines.md
@@ -1,0 +1,99 @@
+# Git Commit Guidelines
+
+We have very precise rules over how our git commit messages can be formatted.
+This leads to **more readable messages** that are easy to follow when
+looking through the **project history**.  But also,
+we use the git commit messages to **generate the change log**.
+
+The commit message formatting can be added using a typical git workflow or
+through the use of a CLI wizard ([Commitizen](https://github.com/commitizen/cz-cli)).
+
+### Commit Message Format
+Each commit message consists of a **header**, a **body** and a **footer**.
+The header has a special format that includes a **type**, a **scope** and a **subject**:
+
+```
+<type>(<scope>): <subject>
+<BLANK LINE>
+<body>
+<BLANK LINE>
+<footer>
+```
+
+The **header** is mandatory and the **scope** of the header is optional.
+
+Any line of the commit message cannot be longer 100 characters! This allows the message to be easier
+to read on GitHub as well as in various git tools.
+
+### Revert
+If the commit reverts a previous commit, it should begin with `revert: `,
+followed by the header of the reverted commit. In the body it should
+say: `This reverts commit <hash>.`, where the hash is the SHA of the commit being reverted.
+
+### Type
+Must be one of the following:
+
+* **feat**: A new feature
+* **fix**: A bug fix
+* **docs**: Documentation only changes
+* **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing
+  semi-colons, etc)
+* **refactor**: A code change that neither fixes a bug nor adds a feature
+* **perf**: A code change that improves performance
+* **test**: Adding missing tests
+* **chore**: Changes to the build process or auxiliary tools and libraries such as documentation
+  generation
+
+### Scope
+The scope could be anything specifying place of the commit change. For example `api`,
+`cli`, etc...
+
+### Subject
+The subject contains succinct description of the change:
+
+* use the imperative, present tense: "change" not "changed" nor "changes"
+* don't capitalize first letter
+* no dot (.) at the end
+
+### Body
+Just as in the **subject**, use the imperative, present tense: "change" not "changed" nor "changes".
+The body should include the motivation for the change and contrast this with previous behavior.
+
+### Footer
+The footer should contain any information about **Breaking Changes** and is also the place to
+reference GitHub issues that this commit **Closes**.
+
+**Breaking Changes** should start with the word `BREAKING CHANGE:` with a space or two newlines. The rest of the commit message is then used for this.
+
+## Examples
+
+```
+feat(pencil): add 'graphiteWidth' option
+```
+
+```
+fix(graphite): stop graphite breaking when width < 0.1
+
+Closes #28
+```
+
+```
+perf(pencil): remove graphiteWidth option
+
+BREAKING CHANGE: The graphiteWidth option has been removed. The default graphite width of 10mm is always used for performance reason.
+```
+
+```
+revert: feat(pencil): add 'graphiteWidth' option
+
+This reverts commit 667ecc1654a317a13331b17617d973392f415f02.
+```
+
+## References
+
+This document is based on
+
+- https://github.com/conventional-changelog/conventional-changelog-angular/blob/master/convention.md
+- https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit
+
+more details about the commit convention can also be found in this [document](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y)

--- a/js-commit-guidelines.md
+++ b/js-commit-guidelines.md
@@ -1,16 +1,16 @@
 # Git Commit Guidelines
 
 We have very precise rules over how our git commit messages can be formatted.
-This leads to **more readable messages** that are easy to follow when
-looking through the **project history**.  But also,
-we use the git commit messages to **generate the change log**.
+This leads to *more readable messages* that are easy to follow when
+looking through the *project history*.  But also,
+we use the git commit messages to *generate the change log*.
 
 The commit message formatting can be added using a typical git workflow or
 through the use of a CLI wizard ([Commitizen](https://github.com/commitizen/cz-cli)).
 
 ### Commit Message Format
-Each commit message consists of a **header**, a **body** and a **footer**.
-The header has a special format that includes a **type**, a **scope** and a **subject**:
+Each commit message consists of a *header*, a *body* and a *footer*.
+The header has a special format that includes a *type*, a *scope* and a *subject*:
 
 ```
 <type>(<scope>): <subject>
@@ -20,7 +20,7 @@ The header has a special format that includes a **type**, a **scope** and a **su
 <footer>
 ```
 
-The **header** is mandatory and the **scope** of the header is optional.
+The *header* is mandatory and the *scope* of the header is optional.
 
 Any line of the commit message cannot be longer 100 characters! This allows the message to be easier
 to read on GitHub as well as in various git tools.
@@ -56,12 +56,12 @@ The subject contains a succinct description of the change:
 * no dot (.) at the end
 
 ### Body
-Just as in the **subject**, use the imperative, present tense: "change" not "changed" nor "changes".
+Just as in the *subject*, use the imperative, present tense: "change" not "changed" nor "changes".
 The body should include the motivation for the change and contrast this with previous behavior.
 
 ### Footer
-The footer should contain any information about **Breaking Changes** and is also the place to
-reference GitHub issues that this commit **Closes**.
+The footer should contain any information about *breaking changes* and is also the place to
+reference GitHub issues that this commit *closes*.
 
 **Breaking Changes** should start with the word `BREAKING CHANGE:` with a space or two newlines. The rest of the commit message is then used for this.
 

--- a/js-commit-guidelines.md
+++ b/js-commit-guidelines.md
@@ -45,11 +45,11 @@ Must be one of the following:
   generation
 
 ### Scope
-The scope could be anything specifying place of the commit change. For example `api`,
+The scope could be anything specifying the place of the commit change. For example `api`,
 `cli`, etc...
 
 ### Subject
-The subject contains succinct description of the change:
+The subject contains a succinct description of the change:
 
 * use the imperative, present tense: "change" not "changed" nor "changes"
 * don't capitalize first letter
@@ -91,9 +91,9 @@ This reverts commit 667ecc1654a317a13331b17617d973392f415f02.
 
 ## References
 
-This document is based on
+This document is based on:
 
 - https://github.com/conventional-changelog/conventional-changelog-angular/blob/master/convention.md
 - https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit
 
-more details about the commit convention can also be found in this [document](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y)
+More details about the commit convention can also be found in this [document](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y).


### PR DESCRIPTION
This is a first draft as discussed in https://github.com/dignifiedquire/aegir/issues/30. 
It is very much based on the referenced angular commit convention. 

Currently there is no mentioning of signing commits. The reason for this is that we would need to change the tooling first to remove those signatures from the changelog. So I want us to be sure we need and want to add this.

cc @diasdavid @VictorBjelkholm @nginnever
