### PR TITLE
Require simple present 3rd-person singular tense for taglines

### DIFF
--- a/docs-styleguide.md
+++ b/docs-styleguide.md
@@ -31,7 +31,7 @@ This is the documentation styleguide for our natural language descriptions used 
 
 * End phrases with a period. (Like that one).
 * Capitalize the first letter of a phrase or sentence.
-* Command & subcommand taglines, (and option descriptions when possible) should use the imperative mood. For example: "Clear a field.", "Interact with the DHT."
+* Command and subcommand taglines (and option descriptions when possible) should use the imperative mood. For example: "Clear a field.", "Interact with the DHT."
 
 ## Headings
 

--- a/docs-styleguide.md
+++ b/docs-styleguide.md
@@ -31,6 +31,7 @@ This is the documentation styleguide for our natural language descriptions used 
 
 * End phrases with a period. (Like that one).
 * Capitalize the first letter of a phrase or sentence.
+* Command & subcommand taglines, (and option descriptions when possible) should use the imperative mood. For example: "Clear a field.", "Interact with the DHT."
 
 ## Headings
 


### PR DESCRIPTION
As previously discussed in https://github.com/ipfs/go-ipfs/pull/3018 . See https://www.grammarly.com/handbook/grammar/verbs/8/simple-present-tense-present-indefinite/ for a description of this tense.

@thomas-gardner pointed out that using simple present 3rd-person singular tense, rather than imperative mood, is contrary to the practices of various other programs/projects. So we may want to follow that, instead. I made it this way to start with, because I already took the time to make all the taglines consistent with this way. But I'm open to switching.