### PR TITLE
Remove Events Section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@
 - [Calendar](#calendar)
 - [Swag](#swag)
 - [People](#people)
-- [Events calendar](#events-calendar)
 - [Contribute](#contribute)
 - [License](#license)
 
@@ -120,21 +119,6 @@ Lars Gierth | [@lgierth](//github.com/lgierth) |  | lgierth
 Matt Bell | [@mappum](//github.com/mappum) | [@mappum](//twitter.com/mappum) | mappum
 Richard Littauer | [@RichardLitt](//github.com/RichardLitt) | [@richlitt](//twitter.com/richlitt) | richardlitt
 Victor Bjelkholm | [@VictorBjelkholm](//github.com/VictorBjelkholm) | [@victorbjelkholm](//twitter.com/victorbjelkholm) | victorbjelkholm
-
-## Events calendar
-
-This is our community events calendar, where we log past and future events like talks, workshops, hackathons and so on, where IPFS is present.
-
-Name                        | Location                      | Date                   | Link
-:-------------------------: | :---------------------------: | :--------------------: | :-------:
-Container Camp              | London - Barbican Center      | September 11, 2015     | [container.camp](https://container.camp/)
-Chaos Communication Congress| Hamburg - CCH                 | December 27 - 30, 2015 | [events.ccc.de](https://events.ccc.de/congress/2015/wiki/Main_Page)
-Berlin IPFS Meetup #1       | Berlin - c-base               | August 27, 2015        |
-Chaos Communication Camp    | Zehdenick - Ziegeleipark      | August 13 - 17, 2015   | [events.ccc.de](https://events.ccc.de/camp/2015/wiki/Main_Page)
-Seattle IPFS Meetup #1      | Seattle - Surf Incubator      | July 23, 2015          | [meetup](http://www.meetup.com/Seattle-IPFS-Meetup/events/224077819/)
-Portland IPFS Meetup #1     | Portland - ctrlH HackerSpace  | July 22, 2015          | [attending](https://attending.io/events/ipfs-portland-meetup-the-permanent-distributed-web)
-Data Terra Nemo 2015        | Berlin                        | May 23-24, 2015        | [dtn](http://dtn.is/)
-FluentConf 2015             | San Francisco                 | April 22, 2015         | [fluent](http://conferences.oreilly.com/fluent/javascript-html-2015/public/schedule/detail/43686)
 
 ## Contribute
 


### PR DESCRIPTION
We dont use this section, or update it, and I am not sure that the information is relevant to anyone. This PR removes it.