### PR TITLE
Add example IPFS README

### DIFF
--- a/examples/ipfs-README.md
+++ b/examples/ipfs-README.md
@@ -1,0 +1,38 @@
+# <topic>
+
+[![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://ipn.io)
+[![](https://img.shields.io/badge/project-IPFS-blue.svg?style=flat-square)](https://ipfs.io)
+[![](https://img.shields.io/badge/freenode-%23ipfs-blue.svg?style=flat-square)](https://webchat.freenode.net/?channels=%23ipfs)
+[![](https://img.shields.io/badge/readme%20style-standard-brightgreen.svg?style=flat-square)](https://github.com/RichardLitt/standard-readme)
+
+> <description>
+
+<long description>
+
+## Table of Contents
+
+<ToC>
+
+## Install
+
+<install>
+
+## Usage
+
+<usage>
+
+## Maintainers
+
+Captain: [<lead>](https://github.com/<lead>).
+
+## Contribute
+
+Please contribute! [Look at the issues](https://github.com/ipfs/<repo name>/issues)!
+
+Check out our [contributing document](https://github.com/ipfs/ipfs/blob/master/contribute.md) for more information on how we work, and about contributing in general. Please be aware that all interactions related to IPFS are subject to the IPFS [Code of Conduct](https://github.com/ipfs/community/blob/master/code-of-conduct.md).
+
+Small note: If editing the README, please conform to the [standard-readme](https://github.com/RichardLitt/standard-readme) specification.
+
+## License
+
+[MIT](LICENSE) © 2016 Protocol Labs Inc.


### PR DESCRIPTION
This adds an example IPFS README that conforms to standard-readme and should be able to help with making new READMEs for IPFS repositories. It is language agnostic. However, it is based on a request by the JS team (specifically, @diasdavid) in https://github.com/ipfs/community/issues/225#issuecomment-272419143