### PR TITLE
Adding a libp2p example readme

### DIFF
--- a/examples/readme-templates/libp2p.md
+++ b/examples/readme-templates/libp2p.md
@@ -1,0 +1,38 @@
+# <topic>
+
+[![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://ipn.io)
+[![](https://img.shields.io/badge/project-libp2p-blue.svg?style=flat-square)](http://github.com/libp2p/libp2p)
+[![](https://img.shields.io/badge/freenode-%23ipfs-blue.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23ipfs)
+[![](https://img.shields.io/badge/readme%20style-standard-brightgreen.svg?style=flat-square)](https://github.com/RichardLitt/standard-readme)
+
+> <description>
+
+<long description>
+
+## Table of Contents
+
+<ToC>
+
+## Install
+
+<install>
+
+## Usage
+
+<usage>
+
+## Lead
+
+- [<lead>](https://github.com/<lead>)
+
+## Contribute
+
+Please contribute! [Look at the issues](https://github.com/libp2p/<repoName>/issues)!
+
+Check out our [contributing document](https://github.com/libp2p/community/blob/master/CONTRIBUTE.md) for more information on how we work, and about contributing in general. Please be aware that all interactions related to libp2p are subject to the IPFS [Code of Conduct](https://github.com/ipfs/community/blob/master/code-of-conduct.md).
+
+Small note: If editing the README, please conform to the [standard-readme](https://github.com/RichardLitt/standard-readme) specification.
+
+## License
+
+[MIT](LICENSE) © 2016 Protocol Labs Inc.


### PR DESCRIPTION
I realize that there isn't one. This should change that.