### PR TITLE
Update Github Issue Search Hyperlink to find easy issues.

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -50,7 +50,7 @@ There is also a more extensive [code-of-conduct](code-of-conduct.md).
 
 ### Dive Right In
 
-If you're curious to hack on IPFS right now and you just need an issue to focus on, check out [this search](https://github.com/search?utf8=%E2%9C%93&q=label%3A%22difficulty%3Aeasy%22+user%3AIPFS+is%3Aopen&type=Issues&ref=searchresults) for issues tagged as "help wanted". Generally, these should be easier for newcomers, and are great places to start hacking away. Have fun!
+If you're curious to hack on IPFS right now and you just need an issue to focus on, check out [this search](https://github.com/search?utf8=%E2%9C%93&q=label%3A%22difficulty%3Aeasy%22+label%3A%22help+wanted%22+user%3AIPFS+is%3Aopen+&type=Issues) for issues tagged as "help wanted". Generally, these should be easier for newcomers, and are great places to start hacking away. Have fun!
 
 ### Reporting Issues
 


### PR DESCRIPTION
Add " label:"help wanted" to search parameters, when searching for To-Dos. This performs the search: label:"difficulty:easy" label:"help wanted" user:IPFS is:open which shows all issues at the intersection of label:"difficulty:easy", label:"help wanted", user:IPFS, and is:open.