### PR TITLE
Make sure all modules have two publishers

### DIFF
--- a/js-code-guidelines.md
+++ b/js-code-guidelines.md
@@ -117,7 +117,7 @@ Currently, there is no formal test or request form to do so. Lead Maintainers wi
 - Update each package.json and README.md to have a `leadMaintainer` field.
 - Update packages table on each entry module (e.g https://github.com/ipfs/js-ipfs#packages) to also list the maintainer for each.
 - Protect the master branch and only grant permissions for merge to the Maintainer and the Tech Lead, only.
-- Grant publish permission to the Maintainer and Tech Lead, only.
+- Grant publish permission to the Maintainer and Tech Lead (or another Tech Lead if it’s the same person), only.
 
 ## Contributing
 


### PR DESCRIPTION
If the Lead Maintainer and Tech Lead is the same person, another
Tech Lead should also have permission to publish a module. This
reduces risks.