### PR TITLE
WIP: minor js-code-guidelines.md fixes

### DIFF
--- a/js-code-guidelines.md
+++ b/js-code-guidelines.md
@@ -91,7 +91,7 @@ The current Tech Leads are:
 - [David Dias](https://github.com/diasdavid/) for js-ipfs, js-libp2p js-multiformats ecosystems.
 - [Volker Mische](https://github.com/vmx) for the js-ipld ecosystem.
 
-The current Lead Maintainers can be identified either by the `maintainer` field in the package.json of the module and/or the section `Lead Maintainer` in the README.md of the module.
+The current Lead Maintainers can be identified either by the `leadMaintainer` field in the package.json of the module and/or the section `Lead Maintainer` in the README.md of the module.
 
 **Lead Maintainer responsibilities:**
 


### PR DESCRIPTION
Update `maintainer` to `leadMaintainer` as name of field in package.json, to match reality.

Where did `leadMaintainer` come from? It does do a better job of capturing the intent than `author` or `contributors`, but they are the existing standard fields for this info?