### PR TITLE
add procedures for code of conduct violations at events

### DIFF
--- a/code-of-conduct-procedures-for-events.md
+++ b/code-of-conduct-procedures-for-events.md
@@ -1,0 +1,155 @@
+
+# Procedures for handling Code of Conduct violations at events
+
+This procedure documents actions to be taken by event staff and volunteers if a violation of the [Code of Conduct](code-of-conduct.md) is reported.
+
+## Before the event
+
+* Assemble event sub-comittee to handle implementation of procedures.
+* Ensure Local Planning commitee includes a quiet, private space suitable for taking reports in venue requirements.
+* Select duty officers, and familiarize them with this document and the [Code of Conduct](code-of-conduct.md).
+* Identify an organize any required training for duty officers.
+* Decide how event attendees will be able to recognize duty officers, and publicize this.
+* Schedule duty officer shifts.
+* Ensure that leaders of official off-site events (tours / newcomer dinners, etc) are familar with the Code of Conduct.
+* Decide which event organizers will be responsible for incident response, and familiarize them with this document and the Code of Conduct.
+* Make sure all of the people in this section have each others' contact information.
+* Consult prior event organizers for any knowledge they need to transfer relevant to enforcement (e.g. prior incident response; iterations to procedure; or people with ongoing sanctions).
+* Investigate local laws that may affect procedures.
+
+Your duty officers and event organizers should be a small group of kind, articulate, and trustworthy people who reflect the diversity of the event.
+
+
+## If someone reports an incident to you, and you are not a duty officer
+
+* Get a duty officer as soon as possible.
+* Take all complaints seriously, and assure reporters that the event does as well.
+* Do not question the reporter's truthfulness. It is your job to maintain a supportive environment and ensure that fair procedures are followed, not to conduct an investigation.
+* Do not summon law enforcement except if there is a threat to physical safety, or at the request of the reporter (see _Threats to physical safety_, below).
+
+## Threats to physical safety
+
+### Law enforcement
+If you have any concerns as to anyone's physical safety, contact venue security or local law enforcement immediately.
+
+Do not involve law enforcement under any other circumstances except by request of the reporter. Remember that some attendees will experience law enforcement as increasing, not diminishing, threats to their safety, so it is very important that they be in control of this choice.
+
+### Other
+* Offer the reporter a private space to be in.
+* Ask if there is a trusted friend they would like you to get; if so, have someone bring that person.
+* Ask how you can help.
+* Make sure they have local emergency contact information.
+* Offer (but do not insist upon) your help if they report to emergency contacts.
+
+## Duty officers
+
+Duty officers should be clearly indicated (at a specified location, wearing something distinctive). They should be available at all official events and related activities, including social events.
+
+Have enough duty officers that no one has to be constantly on, and schedule shifts.
+
+The duty officer should be constantly interruptible, so they shouldn't also be doing noninterruptible event tasks (e.g. livestreaming).
+
+The duty officers' job is to:
+* Take reports (see below)
+* Refer reporters to appropriate services (e.g. event staff for incident response, medical or other emergency services) (* TODO: do we need to spell out duty officer referral options/criteria)
+
+The duty officers' job is _not_ to:
+* Respond to front-line customer service queries (these are probably best hanled by the registration desk)
+* Be everyone's pal
+* Follow reporters to offsite medical or other services (duty officers need to stay onsite; delegate this task to someone the reporter trusts if needed)
+* Put themselves in danger (_DO NOT DO THIS FOR ANY REASON_. Your personal safety supersedes your duty officer responsibilities.)
+
+Duty officers going off-shift should brief those coming on about recent incidents, if applicable.
+
+Conference organizers should recognize the handles that duty officers will use to contact them (phone numbers, IRC nicks, etc. - decide in advance and collate this info). They should treat contacts from duty officers as priority interrupts.
+
+### Supplies
+* Working, charged phone and charger
+* Walkie Talkies for duty officer and organizing committee
+* Contact information for senior event organizers
+* Local contact information: emergency services, venue security, taxi companies, mental health crisis hotline, sexual assault crisis hotline
+* Venue maps, including accessibility information
+* Read/write access to incident logs from all duty officers at this event
+* Unadvertised petty cash (e.g. for people who need cab fare following an incident)
+* Access to a quiet, private space suitable for taking reports
+* The contents of the _Taking reports_ section of this document
+
+## Taking reports
+
+Take a written report, or write down verbal reports as soon as possible.
+
+Do distribute this report immediately to the event organizers and duty officers; do not distribute it beyond that group.
+
+Reports of any length should be taken in a quiet, private space (_not_ a duty officer's hotel room).
+
+The person reporting the incident can choose to provide or withhold any information from the report. Ask for this information and include it if given, but do not pressure them.
+
+* Identifying information (name if possible) of the participant doing the harassing
+* The behavior that was in violation
+* The approximate time of the behavior (if different than the time the report was made)
+* The circumstances surrounding the incident
+* Other people involved in the incident
+
+## Immediate response to reports
+
+_If the incident was widely witnessed_: Thank them for the report and tell them you will convene the relevant event staff.
+
+_If the incident was private_: Thank them for the report and say you will convene the relevant event staff _if that is okay with them_. Consent is critical. Do not...
+* Pressure them to withdraw the complaint
+* Ask for their advice on handling the complaint or imposing penalties: this is the event staff's responsibility
+* Share details of the incident with anyone, _including event staff_, without the specific consent of the reporter.
+
+Be aware that people who have experienced harassment and abuse may be re-traumatized if the details become public. In addition, abusers may recognize these details, even if they have been anonymized, become angry at the reporter, and enact further trauma. Confidentiality and consent are incredibly important.
+
+## Follow-up response to reports
+
+Do convene a meeting as soon as possible with relevant event staff.
+
+Do let the alleged harasser know that a complaint has been lodged (reread the language above about confidentiality and consent first). Have event staff take a report from them and bring it to the meeting.
+
+Volunteer event staff are not in a position to conduct exhaustive investigations, so don't. It may be necessary and prudent to gather some additional information before reaching a decision, however.
+
+At the meeting, discuss:
+* What happened?
+* Are you doing anything about it?
+* If so, who is doing it?
+* When will they do it?
+
+There is a list of potential sanctions at http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Responding_to_reports . Consult that if needed. Keep in mind that it is _never a good idea to require an apology_. If a harasser would like to apologize, this may also be a bad idea; consult this link for details.
+
+Do not include the reporter, the alleged harasser, or anyone with a conflict of interest at this meeting.
+
+As soon as possible after the meeting, communicate your decision and any actions you are taking to involved parties.
+
+## Communications with the community at large
+First, reread the language above about confidentiality and consent, and consider this section in that light.
+
+_Your goal is to be transparent about your process and values while respecting the privacy of individuals involved. Keep it brief and clear._
+
+* Do keep individuals on both sides of an incident anonymous. (Potential exceptions: when a harasser is an event staffer; when the incident was public and high-profile.)
+* Do provide a general sense of the nature of the incident.
+* Do say what you have done in response to the incident.
+* You may briefly note any steps taken by harassers to remedy the situation (e.g. apology, leaving the event). Don't give them a cookie for it.
+* Do provide avenues for community feedback to event staff. This feedback should be private. If you provide only one feedback mechanism, make sure it is accessible to everyone (e.g. email good, in-person conversations bad).
+* Do respond quickly.
+* Do reiterate your values.
+
+When incidents like this, there are often upset community members who want to talk. Conference staff should listen to them nonjudgmentally, take notes if needed, thank them for their feedback, and not flip into problem-solving or explaining mode. Apologize as needed; avoid defensiveness.
+
+## After the event
+
+If someone's conduct was egregious enough that they should be banned or otherwise sanctioned in future years, this needs to be recorded and communicated to future event organizers and to the leadership of the IPFS community.
+
+* Event organizers have the responsibility to ensure that records are stored securely, disseminated as-needed in the course of organizing the event, and updated as needed.
+* Event organizers are responsible for ensuring that anyone to whom the records are disclosed are aware of this document, aware of the privacy policy regarding the records, and are not themselves associated with any records in a way that could create a breach of privacy.
+
+If your responses to an incident needs to continue after the event, the event organizers are responsible for ensuring the continued response.  
+
+## Credits and further reading
+
+_This document is derived from the [procedures](https://github.com/code4lib/code-of-conduct/blob/master/procedures.md) portion of the [Code4Lib Code of Conduct](https://github.com/code4lib/code-of-conduct)_
+
+Further reading:
+- http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/ and subpages (<-- the direct quote from this necessitates a CC *-SA license on this content)  
+- https://adainitiative.org/2014/07/handling-harassment-incidents-swiftly-and-safely/
+- http://blogs.publishersweekly.com/blogs/genreville/?p=2160  

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -88,6 +88,8 @@ Conduct, please contact us at abuse@ipfs.io to send us an abuse report. If
 this is the initial report of a problem, please include as much detail as
 possible. It is easiest for us to address issues when we have more context.
 
+If you are at an event organized by the IPFS community, contact a _duty officer_ or event staff. To learn more about our procedures handling incidents and reports at events, read the [procedures for in-person events](code-of-conduct-procedures-for-events.md)
+
 ## Copyright Violations
 
 We respect the intellectual property of others and ask that you do too. If you


### PR DESCRIPTION
adds procedures from [Code4Lib Code of Conduct](https://github.com/code4lib/code-of-conduct) for handling reports of CoC violations at in-person events/meetings/conferences

This has mostly the same stuff as PR #325 but is slightly simplified.