### PR TITLE
Add missing words in suggested README text for licensing policy

### DIFF
--- a/docs/licensing-policy.md
+++ b/docs/licensing-policy.md
@@ -32,7 +32,7 @@ When licensing a project, be sure to:
     
     All software code is copyright (c) Protocol Labs, Inc. under the **MIT license**.
     
-    Other written documentation and content (c) Protocol Labs, Inc. under the **Creative Commons Attribution License**.
+    Other written documentation and content is copyright (c) Protocol Labs, Inc. under the **Creative Commons Attribution License**.
     
     See [LICENSE file](./LICENSE) for details.
     ```


### PR DESCRIPTION
I think this was a typo on my part initially — we still have to say "copyright" before the "(c)" for the CC license :P