### PR TITLE
doc: use github name for leadMaintainer in README

### DIFF
--- a/js-code-guidelines.md
+++ b/js-code-guidelines.md
@@ -92,7 +92,7 @@ The current Tech Leads are:
 - [David Dias](https://github.com/diasdavid/) for js-ipfs, js-libp2p js-multiformats ecosystems.
 - [Volker Mische](https://github.com/vmx) for the js-ipld ecosystem.
 
-The current Lead Maintainers can be identified either by the `leadMaintainer` field in the package.json of the module and/or the section `Lead Maintainer` in the README.md of the module.
+The current Lead Maintainers can be identified either by the `leadMaintainer` field in the package.json of the module and/or the section `Lead Maintainer` in the README.md of the module. When adding a `leadMaintainer` to a README you should use their GitHub name.
 
 **Lead Maintainer responsibilities:**
 


### PR DESCRIPTION
Following up with a quick process change discussed [here](https://github.com/ipld/js-ipld/pull/160#issuecomment-427671728).

Once this lands we can followup with PR's to the individual repos to change these in all the project.