### PR TITLE
remove out of date issue trackers and direct users to the forums

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,12 +74,12 @@ If you find bugs, mistakes, inconsistencies in the IPFS project's code or docume
 The main issues for bug reporting are as follows:
 - [go-ipfs/issues](https://github.com/ipfs/go-ipfs/issues) - Issues related to running the Go implementation of IPFS.
 - [js-ipfs/issues](https://github.com/ipfs/js-ipfs/issues) - Issues related to running the js implementation of IPFS.
-- [support/issues](https://github.com/ipfs/support/issues) - If you're not sure but you need support on running IPFS.
 - [notes/issues](https://github.com/ipfs/notes/issues) - For general notes and ideas.
-- [faq/issues](https://github.com/ipfs/faq/issues) - For questions.
 - [specs/issues](https://github.com/ipfs/specs/issues) - For protocol discussions.
 
 The [go-ipfs](https://github.com/ipfs/go-ipfs) issues use a template that will guide you through the process of reporting a bug. We will be adding this kind of issue template to other repositories as bug reports become more common.
+
+For all other questions/discussions, please visit the [discussion forum](https://discuss.ipfs.io)
 
 ## Protocol Design
 


### PR DESCRIPTION
These have been deprecated for a while.