### PR TITLE
Community Roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,101 @@
+# IPFS Community Working Group Roadmap
+
+The full description of the Community WG and its responsibilities are 
+[here](https://github.com/mikeal/team-mgmt/blob/master/TEAM_STRUCTURES.md#community).
+
+## Community WG Vision
+
+To create one of the largest communities and ecosystems in Open Source.
+
+## Requirements
+
+1. IPFS must be easy to learn to use.
+2. IPFS must be easy to create libraries on top of.
+3. IPFS must be easy to contribute to.
+4. People need to know about IPFS and how it can solve their problems.
+
+# Top Level Goals
+
+1. Create great entry points for people to learn IPFS.
+   * Project: [ProtoSchool.](#ProtoSchool)
+   * Project: [Documentation Iteration.](#Documentation-Iteration)
+   * Project: [Use Case Specific Quickstarts](#Use-Case-Specific-Quickstarts)
+   * Measuring Success:
+     * \# unique developers that use a resource each month.
+     * % growth of this metric over time.
+     
+2. Create a great new contributor experience that grows outside contributions.
+   * Project: [First Commit Events.](#First-Commit-Events)
+   * Project: [Automated Workflow Enhancements.](#Automated-Workflow-Enhancements)
+   * Measuring Success:
+     * \# new contributors each month.
+     * average time to land every pull request.
+     * % retention of new contributors.
+     * % growth of PRs from external (non-PL paid) contributors.
+     * % growth of unique people commenting on GH issues and PRs.
+
+3. Evangelize IPFS
+   * Project: [Deploy to IPFS GitHub Automation.](#Deploy-to-IPFS-GitHub-Automation)
+   * Measuring Success:
+     * % growth of projects that depend on IPFS.
+     * % growth of unique people commenting on all projects that depend on or use IPFS.
+     * % growth of media regarding IPFS.
+
+# Projects
+
+## ProtoSchool
+
+ProtoSchool is an entry point for people with little to no prior knowledge of decentralized technologies, 
+blockchain, content addressing, etc.
+
+Note: ProtoSchool is being bootstrapped in the IPFS Community WG but will eventually be spun out into 
+its own project as it will tackle more than *just* IPFS.
+
+* Milestone #1 (Q4 2018): [1.0 Release](https://github.com/ipfs-shipyard/proto.school/issues/50)
+* Milestone #2 (Q1 2019): Public Launch.
+* Milestone #3 (Q1 2019): ProtoSchool Roadmap.
+* Measuring Success:
+  * Unique site visitors per month.
+  * Average % completeness of each workshop.
+  * \# of local chapters.
+
+## Documentation Improvements
+
+The Community WG is in the early research phase of how to best improve the documentation of IPFS. 
+You can see and contribute to that conversation [here](https://github.com/ipfs/community/issues/367).
+
+* Milestone #1 (Q1 2019): Documentation Roadmap
+
+## Use Case Specific Quickstarts
+
+The Community WG is planning to create starter kits which help people build on top of IPFS right away, 
+like [Truffle Boxes](https://truffleframework.com/boxes).
+
+* Milestone #1 (Q4 2018): [Identify first set of use cases](https://github.com/ipfs/community/issues/368).
+* Measuring Success:
+  * \# of uses of each quickstart.
+
+## First Commit Events
+
+These are in-person events designed to guide every participant through landing a pull request on IPFS.
+
+The Community WG is in the early learning phase, documenting the key challenges of contributing to IPFS
+by working through process by hand as well as running some early events in order to learn from the 
+experience of the attendees.
+
+If you have points of friction you've experienced contributing to IPFS please let us know 
+[here](https://github.com/ipfs/community/issues/369).
+
+* Milestone #1 (Q4 2018): Run one “First Commit” event and document learnings.
+
+## Automated Workflow Enhancements
+
+The Community WG is conducting a review of existing GitHub automation tools to consider
+adding to the IPFS org. If there's some GitHub based automation you've used in the past
+that you particularly liked please tell us about it [here](https://github.com/ipfs/community/issues/370).
+
+* Milestone #1 (Q1 2019): Review existing Probot and GitHub Actions.
+
+## Deploy to IPFS GitHub Automation
+
+* Milestone #1 (Q4 2018): [Define project and dependencies for implementation in 2019](https://github.com/ipfs/community/issues/371).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -51,7 +51,7 @@ blockchain, content addressing, etc.
 Note: ProtoSchool is being bootstrapped in the IPFS Community WG but will eventually be spun out into 
 its own project as it will tackle more than *just* IPFS.
 
-* Milestone #1 (Q4 2018): [1.0 Release](https://github.com/ipfs-shipyard/proto.school/issues/50)
+* Milestone #1 (Q4 2018): [1.0 Release](https://github.com/ipfs-shipyard/proto.school/milestone/1)
 * Milestone #2 (Q1 2019): Public Launch.
 * Milestone #3 (Q1 2019): ProtoSchool Roadmap.
 * Measuring Success:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -86,7 +86,7 @@ experience of the attendees.
 If you have points of friction you've experienced contributing to IPFS please let us know 
 [here](https://github.com/ipfs/community/issues/369).
 
-* Milestone #1 (Q4 2018): Run one “First Commit” event and document learnings.
+* Milestone #1 (Q4 2018): [Run one “First Commit” event and document learnings](https://github.com/protocol/event-management/issues/132).
 
 ## Automated Workflow Enhancements
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -66,7 +66,7 @@ You can see and contribute to that conversation [here](https://github.com/ipfs/c
 
 * Milestone #1 (Q1 2019): Documentation Roadmap
 
-## Use Case Specific Quickstarts
+## Use-Case-Specific Quickstarts
 
 The Community WG is planning to create starter kits which help people build on top of IPFS right away,
 like [Truffle Boxes](https://truffleframework.com/boxes).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # IPFS Community Working Group Roadmap
 
-The full description of the Community WG and its responsibilities are 
+The full description of the Community WG and its responsibilities are
 [here](https://github.com/mikeal/team-mgmt/blob/master/TEAM_STRUCTURES.md#community).
 
 ## Community WG Vision
@@ -9,93 +9,93 @@ To create one of the largest communities and ecosystems in Open Source.
 
 ## Requirements
 
-1. IPFS must be easy to learn to use.
-2. IPFS must be easy to create libraries on top of.
-3. IPFS must be easy to contribute to.
-4. People need to know about IPFS and how it can solve their problems.
+1. IPFS must be easy to learn to use
+2. IPFS must be easy to create libraries on top of
+3. IPFS must be easy to contribute to
+4. People need to know about IPFS and how it can solve their problems
 
 # Top Level Goals
 
-1. Create great entry points for people to learn IPFS.
-   * Project: [ProtoSchool.](#ProtoSchool)
-   * Project: [Documentation Iteration.](#Documentation-Iteration)
+1. Create great entry points for people to learn IPFS
+   * Project: [ProtoSchool](#ProtoSchool)
+   * Project: [Documentation Iteration](#Documentation-Iteration)
    * Project: [Use Case Specific Quickstarts](#Use-Case-Specific-Quickstarts)
    * Measuring Success:
-     * \# unique developers that use a resource each month.
-     * % growth of this metric over time.
-     
-2. Create a great new contributor experience that grows outside contributions.
-   * Project: [First Commit Events.](#First-Commit-Events)
-   * Project: [Automated Workflow Enhancements.](#Automated-Workflow-Enhancements)
+     * \# unique developers that use a resource each month
+     * % growth of this metric over time
+
+2. Create a great new contributor experience that grows outside contributions
+   * Project: [First Commit Events](#First-Commit-Events)
+   * Project: [Automated Workflow Enhancements](#Automated-Workflow-Enhancements)
    * Measuring Success:
-     * \# new contributors each month.
-     * average time to land every pull request.
-     * % retention of new contributors.
-     * % growth of PRs from external (non-PL paid) contributors.
-     * % growth of unique people commenting on GH issues and PRs.
+     * \# new contributors each month
+     * average time to land every pull request
+     * % retention of new contributors
+     * % growth of PRs from external (non-PL paid) contributors
+     * % growth of unique people commenting on GH issues and PRs
 
 3. Evangelize IPFS
-   * Project: [Deploy to IPFS GitHub Automation.](#Deploy-to-IPFS-GitHub-Automation)
+   * Project: [Deploy to IPFS GitHub Automation](#Deploy-to-IPFS-GitHub-Automation)
    * Measuring Success:
-     * % growth of projects that depend on IPFS.
-     * % growth of unique people commenting on all projects that depend on or use IPFS.
-     * % growth of media regarding IPFS.
+     * % growth of projects that depend on IPFS
+     * % growth of unique people commenting on all projects that depend on or use IPFS
+     * % growth of media regarding IPFS
 
 # Projects
 
 ## ProtoSchool
 
-ProtoSchool is an entry point for people with little to no prior knowledge of decentralized technologies, 
+ProtoSchool is an entry point for people with little to no prior knowledge of decentralized technologies,
 blockchain, content addressing, etc.
 
-Note: ProtoSchool is being bootstrapped in the IPFS Community WG but will eventually be spun out into 
+Note: ProtoSchool is being bootstrapped in the IPFS Community WG but will eventually be spun out into
 its own project as it will tackle more than *just* IPFS.
 
 * Milestone #1 (Q4 2018): [1.0 Release](https://github.com/ipfs-shipyard/proto.school/milestone/1)
-* Milestone #2 (Q1 2019): Public Launch.
-* Milestone #3 (Q1 2019): ProtoSchool Roadmap.
+* Milestone #2 (Q1 2019): Public Launch
+* Milestone #3 (Q1 2019): ProtoSchool Roadmap
 * Measuring Success:
-  * Unique site visitors per month.
-  * Average % completeness of each workshop.
-  * \# of local chapters.
+  * Unique site visitors per month
+  * Average % completeness of each workshop
+  * \# of local chapters
 
 ## Documentation Improvements
 
-The Community WG is in the early research phase of how to best improve the documentation of IPFS. 
+The Community WG is in the early research phase of how to best improve the documentation of IPFS.
 You can see and contribute to that conversation [here](https://github.com/ipfs/community/issues/367).
 
 * Milestone #1 (Q1 2019): Documentation Roadmap
 
 ## Use Case Specific Quickstarts
 
-The Community WG is planning to create starter kits which help people build on top of IPFS right away, 
+The Community WG is planning to create starter kits which help people build on top of IPFS right away,
 like [Truffle Boxes](https://truffleframework.com/boxes).
 
 * Milestone #1 (Q4 2018): [Identify first set of use cases](https://github.com/ipfs/community/issues/368).
 * Measuring Success:
-  * \# of uses of each quickstart.
+  * \# of uses of each quickstart
 
 ## First Commit Events
 
 These are in-person events designed to guide every participant through landing a pull request on IPFS.
 
 The Community WG is in the early learning phase, documenting the key challenges of contributing to IPFS
-by working through process by hand as well as running some early events in order to learn from the 
+by working through process by hand as well as running some early events in order to learn from the
 experience of the attendees.
 
-If you have points of friction you've experienced contributing to IPFS please let us know 
+If you have points of friction you've experienced contributing to IPFS please let us know
 [here](https://github.com/ipfs/community/issues/369).
 
-* Milestone #1 (Q4 2018): [Run one “First Commit” event and document learnings](https://github.com/protocol/event-management/issues/132).
+* Milestone #1 (Q4 2018): [Run one “First Commit” event and document learnings](https://github.com/protocol/event-management/issues/132)
 
 ## Automated Workflow Enhancements
 
 The Community WG is conducting a review of existing GitHub automation tools to consider
 adding to the IPFS org. If there's some GitHub based automation you've used in the past
-that you particularly liked please tell us about it [here](https://github.com/ipfs/community/issues/370).
+that you particularly liked please tell us about it [here](https://github.com/ipfs/community/issues/370)
 
-* Milestone #1 (Q1 2019): Review existing Probot and GitHub Actions.
+* Milestone #1 (Q1 2019): Review existing Probot and GitHub Actions
 
 ## Deploy to IPFS GitHub Automation
 
-* Milestone #1 (Q4 2018): [Define project and dependencies for implementation in 2019](https://github.com/ipfs/community/issues/371).
+* Milestone #1 (Q4 2018): [Define project and dependencies for implementation in 2019](https://github.com/ipfs/community/issues/371)


### PR DESCRIPTION
After a lot of planning with the rest of the IPFS project the short terms goals and timeline for the Community WG have been defined.

I've adapted our prior roadmap into a format that is much more understandable by people who haven't been involved in the IPFS planning process. Terms like "KPI" have been remove and replaced with more descriptive language like "Success Criteria." 

I've also made sure that each project has at least one link someone can go to if they are interested in contributing to the project at what ever stage it is at.