### PR TITLE
[WIP] 2019 Q1 OKR's

### DIFF
--- a/okrs/2019-q1.md
+++ b/okrs/2019-q1.md
@@ -2,23 +2,23 @@
 
 | Key Result | Assignee | Mid-Q Score | Projected Score | Final Score |
 | ---------- | -------- | ----------- | --------------- | ----------- |
-| ProtoSchool has its own Roadmap. | @terichadbourne | | | |
-| ProtoSchool has rich metrics that can be used to improve it in the future. | @terichadbourne | | | |
-| Developers can author new ProtoSchool tutorials that require file drops/uploads. | @mikeal | | | |
-| ProtoSchool has an IPFS file sharing tutorial. | @terichadbourne | | | |
+| [ProtoSchool has its own Roadmap.](https://github.com/ProtoSchool/protoschool.github.io/issues/104) | @terichadbourne | | | |
+| [ProtoSchool has rich metrics that can be used to improve it in the future.](https://github.com/ProtoSchool/protoschool.github.io/issues/100) | @terichadbourne | | | |
+| [Developers can author new ProtoSchool tutorials that require file drops/uploads.](https://github.com/ProtoSchool/protoschool.github.io/issues/91) | @mikeal | | | |
+| [ProtoSchool has an IPFS file sharing tutorial.](https://github.com/ProtoSchool/protoschool.github.io/issues/91) | @terichadbourne | | | |
 
 ## Objective: js-ipfs is an inviting project to use and contribute to.
 
 | Key Result | Assignee | Mid-Q Score | Projected Score | Final Score |
 | ---------- | -------- | ----------- | --------------- | ----------- |
-| "First Contributor" guidelines are documented and separate from committer policies. | @pkafei | | | |
-| First time contributors are greeted by an inviting automated message. | @pkafei | | | |
-| `js-ipfs` can be used without waiting for a "ready" event. | @pkafei | | | |
+| ["First Contributor" guidelines are documented and separate from committer policies.](https://github.com/ipfs/community/issues/380) | @pkafei | | | |
+| [First time contributors are greeted by an inviting automated message.](https://github.com/ipfs/community/issues/369) | @pkafei | | | |
+| [`js-ipfs` can be used without waiting for a "ready" event.](https://github.com/ipfs/js-ipfs/issues/1762) | @pkafei | | | |
 
 ## Objective: Developers can discover how to solve problems with IPFS.
 
 | Key Result | Assignee | Mid-Q Score | Projected Score | Final Score |
 | ---------- | -------- | ----------- | --------------- | ----------- |
-| Community WG has a taxonomy of resources (stackoverflow, docs, micro-sites) people find when developer on IPFS. | @pkafei | | | |
-| "The Protocol" is a public publication with 3+ articles. | @terichadbourne | | | |
+| [Community WG has a taxonomy of resources (stackoverflow, docs, micro-sites) people find when developer on IPFS.](https://github.com/ipfs/community/issues/367) | @pkafei | | | |
+| ["The Protocol" is a public publication with 3+ articles.](https://github.com/ipfs/community/issues/333) | @terichadbourne | | | |
 

--- a/okrs/2019-q1.md
+++ b/okrs/2019-q1.md
@@ -1,0 +1,24 @@
+## Objective: ProtoSchool is a growing Top Level Project.
+
+| Key Result | Assignee | Mid-Q Score | Projected Score | Final Score |
+| ---------- | -------- | ----------- | --------------- | ----------- |
+| ProtoSchool has its own Roadmap. | @terichadbourne | | | |
+| ProtoSchool has rich metrics that can be used to improve it in the future. | @terichadbourne | | | |
+| Developers can author new ProtoSchool tutorials that require file drops/uploads. | @mikeal | | | |
+| ProtoSchool has an IPFS file sharing tutorial. | @terichadbourne | | | |
+
+## Objective: js-ipfs is an inviting project to use and contribute to.
+
+| Key Result | Assignee | Mid-Q Score | Projected Score | Final Score |
+| ---------- | -------- | ----------- | --------------- | ----------- |
+| "First Contributor" guidelines are documented and separate from committer policies. | @pkafei | | | |
+| First time contributors are greeted by an inviting automated message. | @pkafei | | | |
+| `js-ipfs` can be used without waiting for a "ready" event. | @pkafei | | | |
+
+## Objective: Developers can discover how to solve problems with IPFS.
+
+| Key Result | Assignee | Mid-Q Score | Projected Score | Final Score |
+| ---------- | -------- | ----------- | --------------- | ----------- |
+| Community WG has a taxonomy of resources (stackoverflow, docs, micro-sites) people find when developer on IPFS. | @pkafei | | | |
+| "The Protocol" is a public publication with 3+ articles. | @terichadbourne | | | |
+

--- a/okrs/2019-q1.md
+++ b/okrs/2019-q1.md
@@ -19,6 +19,5 @@
 
 | Key Result | Assignee | Mid-Q Score | Projected Score | Final Score |
 | ---------- | -------- | ----------- | --------------- | ----------- |
-| [Community WG has a taxonomy of resources (stackoverflow, docs, micro-sites) people find when developer on IPFS.](https://github.com/ipfs/community/issues/367) | @pkafei | | | |
+| [Community WG has a taxonomy of resources (stackoverflow, docs, micro-sites) people find when developing on IPFS.](https://github.com/ipfs/community/issues/367) | @pkafei | | | |
 | ["The Protocol" is a public publication with 3+ articles.](https://github.com/ipfs/community/issues/333) | @terichadbourne | | | |
-


### PR DESCRIPTION
I'm trying something a little different with the Q1 OKR's this time around. Instead of a spreadsheet I'm going to see if we can use a markdown file in the repo.

This is an experiment, it may succeed or it may fail horribly :) It's certainly **not** easier to write OKR's in this format, but it does add something to the discoverability and once I put a link to an active issue in here for every OKR it'll be a lot more useful.