### PR TITLE
docs: add priority badge example to OKR doc

### DIFF
--- a/okrs/2019-q1.md
+++ b/okrs/2019-q1.md
@@ -1,11 +1,11 @@
 ## Objective: ProtoSchool is a growing Top Level Project.
 
-| Key Result | Assignee | Mid-Q Score | Projected Score | Final Score |
-| ---------- | -------- | ----------- | --------------- | ----------- |
-| [ProtoSchool has its own Roadmap.](https://github.com/ProtoSchool/protoschool.github.io/issues/104) | @terichadbourne | | | |
-| [ProtoSchool has rich metrics that can be used to improve it in the future.](https://github.com/ProtoSchool/protoschool.github.io/issues/100) | @terichadbourne | | | |
-| [Developers can author new ProtoSchool tutorials that require file drops/uploads.](https://github.com/ProtoSchool/protoschool.github.io/issues/91) | @mikeal | | | |
-| [ProtoSchool has an IPFS file sharing tutorial.](https://github.com/ProtoSchool/protoschool.github.io/issues/91) | @terichadbourne | | | |
+| Key Result | Priority | Assignee | Mid-Q Score | Projected Score | Final Score |
+| ---------- | -------- | -------- | ----------- | --------------- | ----------- |
+| [ProtoSchool has its own Roadmap.](https://github.com/ProtoSchool/protoschool.github.io/issues/104) |![p0](https://ipfs.io/ipfs/QmV88khHDJEXi7wo6o972MZWY661R9PhrZW6dvpFP6jnMn/p0.svg) | @terichadbourne | | | |
+| [ProtoSchool has rich metrics that can be used to improve it in the future.](https://github.com/ProtoSchool/protoschool.github.io/issues/100) |![p0](https://ipfs.io/ipfs/QmV88khHDJEXi7wo6o972MZWY661R9PhrZW6dvpFP6jnMn/p0.svg)| @terichadbourne | | | |
+| [Developers can author new ProtoSchool tutorials that require file drops/uploads.](https://github.com/ProtoSchool/protoschool.github.io/issues/91) |![p1](https://ipfs.io/ipfs/QmV88khHDJEXi7wo6o972MZWY661R9PhrZW6dvpFP6jnMn/p1.svg)| @mikeal | | | |
+| [ProtoSchool has an IPFS file sharing tutorial.](https://github.com/ProtoSchool/protoschool.github.io/issues/91) |![p2](https://ipfs.io/ipfs/QmV88khHDJEXi7wo6o972MZWY661R9PhrZW6dvpFP6jnMn/p2.svg)| @terichadbourne | | | |
 
 ## Objective: js-ipfs is an inviting project to use and contribute to.
 


### PR DESCRIPTION
I made you some svg priority badges so you can brighten up up your OKR docs if you like them. 

| Job | Priority  |
|-----|---------|
| Do urgent thing | ![p0](https://ipfs.io/ipfs/QmV88khHDJEXi7wo6o972MZWY661R9PhrZW6dvpFP6jnMn/p0.svg) |
| Do thing | ![p1](https://ipfs.io/ipfs/QmV88khHDJEXi7wo6o972MZWY661R9PhrZW6dvpFP6jnMn/p1.svg) |
| Maybe do thing | ![p2](https://ipfs.io/ipfs/QmV88khHDJEXi7wo6o972MZWY661R9PhrZW6dvpFP6jnMn/p2.svg) |


The priorties assigned are just a serving suggestion to demonstrate.
No worries if you have other ideas for prioritising, it was just a bit of fun.
Badges are pinned on cluster and are here https://ipfs.io/ipfs/QmV88khHDJEXi7wo6o972MZWY661R9PhrZW6dvpFP6jnMn