### PR TITLE
Update publication OKR

### DIFF
--- a/okrs/2019-q1.md
+++ b/okrs/2019-q1.md
@@ -20,7 +20,7 @@
 | Key Result | Assignee | Priority | Mid-Q Score | Projected Score | Final Score |
 | ---------- | -------- | -------- | ----------- | --------------- | ----------- |
 | [Community WG has a taxonomy of resources (stackoverflow, docs, micro-sites) people find when developing on IPFS.](https://github.com/ipfs/community/issues/367) | @pkafei | ![p2](https://ipfs.io/ipfs/QmV88khHDJEXi7wo6o972MZWY661R9PhrZW6dvpFP6jnMn/p2.svg) | | | |
-| ["The Protocol" is a public publication with 3+ articles.](https://github.com/ipfs/community/issues/333) | @terichadbourne | ![p0](https://ipfs.io/ipfs/QmV88khHDJEXi7wo6o972MZWY661R9PhrZW6dvpFP6jnMn/p0.svg) | | | |
+| [3+ articles are ready to publish in "The Protocol."](https://github.com/ipfs/community/issues/333) | @terichadbourne | ![p0](https://ipfs.io/ipfs/QmV88khHDJEXi7wo6o972MZWY661R9PhrZW6dvpFP6jnMn/p0.svg) | | | |
 
 ## Objective: Community Sync Automation
 


### PR DESCRIPTION
- Update OKR scope based on discussion with @mikeal and @marvinammori. Revised goals is to get articles ready for publication, but does not include publication launch, which will be handled by the comms team once hired.