### PR TITLE
Clarifying supported Node.js versions

### DIFF
--- a/CONTRIBUTING_JS.md
+++ b/CONTRIBUTING_JS.md
@@ -71,7 +71,7 @@ Always run tests before pushing and PR'ing your code.
 
 #### Supported Versions
 
-The IPFS JavaScript projects work with the Current and Active LTS versions of Node.js and respective npm version that gets installed with Node.js. Please consult [nodejs.org](https://nodejs.org/) for LTS timeline.
+The IPFS JavaScript projects work with the Active LTS versions of Node.js and respective npm version that gets installed with Node.js. Please consult [nodejs.org](https://nodejs.org/) for LTS timeline.
 
 #### Linting & Code Style
 

--- a/CONTRIBUTING_JS.md
+++ b/CONTRIBUTING_JS.md
@@ -71,7 +71,7 @@ Always run tests before pushing and PR'ing your code.
 
 #### Supported Versions
 
-The IPFS JavaScript projects work with the most recent LTS of Node.js and respective npm version that gets installed with Node.js. Please consult [nodejs.org](https://nodejs.org/) for LTS timeline.
+The IPFS JavaScript projects work with the Current and Active LTS versions of Node.js and respective npm version that gets installed with Node.js. Please consult [nodejs.org](https://nodejs.org/) for LTS timeline.
 
 #### Linting & Code Style
 

--- a/CONTRIBUTING_JS.md
+++ b/CONTRIBUTING_JS.md
@@ -71,7 +71,7 @@ Always run tests before pushing and PR'ing your code.
 
 #### Supported Versions
 
-The IPFS JavaScript projects work with the Active LTS versions of Node.js and respective npm version that gets installed with Node.js. Please consult [nodejs.org](https://nodejs.org/) for LTS timeline.
+The IPFS JavaScript projects work with the Current and Active LTS versions of Node.js and respective npm version that gets installed with Node.js. Please consult [nodejs.org](https://nodejs.org/) for LTS timeline.
 
 #### Linting & Code Style
 


### PR DESCRIPTION
I found "most recent LTS" a bit vague. With this change you can go to
https://nodejs.org/en/about/releases/ and clearly see which versions
are supported.

I hope that reflects what the original sentence tried to say. That would
mean that as of today, we support v12 and v14. We **won't** support v10.