### PR TITLE
chore: add js documentation contributing guidelines

### DIFF
--- a/CONTRIBUTING_JS.md
+++ b/CONTRIBUTING_JS.md
@@ -144,7 +144,9 @@ For releasing a js-ipfs, see [RELEASE_ISSUE_TEMPLATE](https://github.com/ipfs/js
 
 #### Documentation
 
-`TBW`
+Documentation will be generated automatically by the JSDoc based TS types in the codebase.
+
+Type definitions and type imports should be created on the top of any JS file (below eventual requires needed). For tooling instructions and best practices, see [Documentation for JSDoc based TS types](https://github.com/ipfs/aegir/blob/master/md/ts-jsdoc.md).
 
 ### Commits
 


### PR DESCRIPTION
Per sync discussion, this PR adds JS documentation contributing guidelines based on JSDoc based types.

The general decision is that type definition should be placed on the top of JS files. 

cc @ipfs/js-core-team 