### PR TITLE
docs: update dependency management recommendations

### DIFF
--- a/CONTRIBUTING_JS.md
+++ b/CONTRIBUTING_JS.md
@@ -262,10 +262,10 @@ NPM uses the `.gitignore` by default, so we have to add a `.npmignore` file to e
 
 ##### Dependency management
 
-We suggest either of these:
+We suggest either of these to keep your dependencies up to date:
 
-- [david-dm](https://david-dm.org/)
-- [greenkeeper](http://greenkeeper.io/) to keep your dependencies up to date.
+- [dependabot](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates)
+- [synk](https://snyk.io/) 
 
 Every module below 1.0.0 should use `~` instead of `^`.
 

--- a/CONTRIBUTING_JS.md
+++ b/CONTRIBUTING_JS.md
@@ -264,6 +264,8 @@ NPM uses the `.gitignore` by default, so we have to add a `.npmignore` file to e
 
 We suggest either of these to keep your dependencies up to date:
 
+
+- [david-dm](https://www.npmjs.com/package/david)
 - [dependabot](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates)
 - [synk](https://snyk.io/) 
 


### PR DESCRIPTION
greenkeeper is pointing to sync, and dependabot is what most open-source and PLN projects use